### PR TITLE
fix: align IOTC flag mapping on FDI terms

### DIFF
--- a/global/firms/gta/codelist_mapping_rfmos_to_global.csv
+++ b/global/firms/gta/codelist_mapping_rfmos_to_global.csv
@@ -9,7 +9,7 @@
 "IATTC","species","codelist_mapping_species_iattc_species_asfis"
 "WCPFC","species","codelist_mapping_species_wcpfc_species_asfis"
 "CCSBT","species","codelist_mapping_species_ccsbt_species_asfis"
-"IOTC","fishingfleet","codelist_mapping_flag_iotc_fishingfleet_firms"
+"IOTC","fishing_fleet","codelist_mapping_flag_iotc_fishingfleet_firms"
 "ICCAT","fishing_fleet","codelist_mapping_flag_iccat_fishingfleet_firms"
 "IATTC","fishing_fleet","codelist_mapping_flag_iattc_fishingfleet_firms"
 "WCPFC","fishing_fleet","codelist_mapping_flag_wcpfc_fishingfleet_firms"


### PR DESCRIPTION
I think this difference for IOTC came from the fact that they were providing the CWP dataset used in the GTA with the column named 'fishingfleet' instead of fishing_fleet.

Since this mapping dataset is also used for effort mapping, it would be cleaner to align it directly with FDI terminology and rename the column upstream in the code from IOTC (for nominal and georeferenced catches), before the mapping. @manuchassot this would possibly impact your pre-harmonisation workflow so just tell me if it should stay as it is.