### PR TITLE
Adding schooltype 'other' for IATTC and ICCAT

### DIFF
--- a/regional-to-global/IATTC/codelist_mapping_schooltype_iattc_schooltype_rfmos.csv
+++ b/regional-to-global/IATTC/codelist_mapping_schooltype_iattc_schooltype_rfmos.csv
@@ -2,3 +2,4 @@
 "DEL","DEL","schooltype_iattc","schooltype_rfmos"
 "NOA","FS","schooltype_iattc","schooltype_rfmos"
 "OBJ","LS","schooltype_iattc","schooltype_rfmos"
+"OTH","OTH","schooltype_iattc","schooltype_rfmos"

--- a/regional-to-global/ICCAT/codelist_mapping_schooltype_iccat_schooltype_rfmos.csv
+++ b/regional-to-global/ICCAT/codelist_mapping_schooltype_iccat_schooltype_rfmos.csv
@@ -1,3 +1,4 @@
 "src_code","trg_code","src_codingsystem","trg_codingsystem"
 "FAD","LS","schooltype_iccat","schooltype_rfmos"
 "FSC","FS","schooltype_iccat","schooltype_rfmos"
+"OTH","OTH","schooltype_iccat","schooltype_rfmos"


### PR DESCRIPTION
adding schooltype 'other' i.e. "unknown" for IATTC and ICCAT as present in 2026 efforts datasets
